### PR TITLE
Change default port to 6868 since 5000 is often occupied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /lidify
 RUN chown -R $UID:$GID /lidify
 # Install requirements and run code as general_user
 RUN pip install --no-cache-dir -r requirements.txt
-EXPOSE 5000
+EXPOSE 6868
 USER general_user
 CMD ["gunicorn", "src.Lidify:app", "-c", "gunicorn_config.py"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ services:
       - /path/to/config:/lidify/config
       - /etc/localtime:/etc/localtime:ro
     ports:
-      - 5000:5000
+      - 6868:6868
     restart: unless-stopped
 ```
 

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,4 @@
-bind = "0.0.0.0:5000"
+bind = "0.0.0.0:6868"
 workers = 1
 threads = 4
 timeout = 120

--- a/src/Lidify.py
+++ b/src/Lidify.py
@@ -332,4 +332,4 @@ def reset():
 
 
 if __name__ == "__main__":
-    socketio.run(app, host="0.0.0.0", port=5000)
+    socketio.run(app, host="0.0.0.0", port=6868)


### PR DESCRIPTION
First of all nice and promissing project. It is something missing in the stack that I did not know that I wanted.

However the Port 5000 is suboptimal at best. It is used by the the docker local registry by default.
Many people that run docker use it either for local builds or as a cache for dockerhub.

May i suggest a change of ports to something in line with the arr stack
from my short research port 6868 (the reverse of lidars 8686) could be used, as it is not used ba any app in the arr stack that I am aware off